### PR TITLE
feat: add OFFLINE_GRACE_PERIOD env to extend keepAlive timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 SERVICE_PORT = 62050
 NODE_HOST = "0.0.0.0"
 
+# OFFLINE_GRACE_PERIOD extends the disconnect timeout beyond the panel's keepAlive value.
+# If the panel goes offline, the node will keep running for this additional duration.
+# Format: Go duration string (e.g. 1h, 30m, 24h). Default: disabled (0).
+# OFFLINE_GRACE_PERIOD = 1h
+
 # use absolute path
 
 # XRAY_EXECUTABLE_PATH = /usr/local/bin/xray

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
 	"sync"
 	"time"
 
@@ -123,6 +124,21 @@ func (c *Controller) keepAliveTracker(ctx context.Context, keepAlive time.Durati
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
+	// OFFLINE_GRACE_PERIOD extends the disconnect timeout on top of keepAlive.
+	// This allows the node to keep running if the panel goes temporarily offline.
+	// Format: Go duration string, e.g. "1h", "30m", "24h".
+	// Default: 0 (original behavior preserved).
+	effectiveTimeout := keepAlive
+	if gp := os.Getenv("OFFLINE_GRACE_PERIOD"); gp != "" {
+		if d, err := time.ParseDuration(gp); err == nil {
+			effectiveTimeout = keepAlive + d
+			log.Printf("offline grace period enabled: keepAlive=%s grace=%s effectiveTimeout=%s",
+				keepAlive, d, effectiveTimeout)
+		} else {
+			log.Printf("warning: invalid OFFLINE_GRACE_PERIOD value %q: %v", gp, err)
+		}
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -131,7 +147,7 @@ func (c *Controller) keepAliveTracker(ctx context.Context, keepAlive time.Durati
 			c.mu.RLock()
 			lastRequest := c.lastRequest
 			c.mu.RUnlock()
-			if time.Since(lastRequest) >= keepAlive {
+			if time.Since(lastRequest) >= effectiveTimeout {
 				log.Println("disconnect automatically due to keep alive timeout")
 				c.Disconnect()
 			}


### PR DESCRIPTION
Adds optional `OFFLINE_GRACE_PERIOD` environment variable that extends the disconnect timeout beyond the panel's keepAlive value. When set, the node continues running Xray for the configured duration even if the panel becomes unreachable, instead of immediately shutting down user connections.

This improves resilience in deployments where the panel may experience temporary downtime (server restart, network issue, maintenance, etc.).

---

## Changes

- **`controller/controller.go`**: Modified `keepAliveTracker` to read `OFFLINE_GRACE_PERIOD` and calculate effective timeout
- **`.env.example`**: Added documentation and example configuration

---

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `OFFLINE_GRACE_PERIOD` not set | Disconnects after keepAlive timeout | Same — no behavior change |
| `OFFLINE_GRACE_PERIOD=1h` | Disconnects after keepAlive timeout | Disconnects after keepAlive + 1h |
| Invalid value (e.g. `OFFLINE_GRACE_PERIOD=abc`) | — | Logs warning, falls back to original keepAlive |

---

## Configuration

```bash
# .env or docker environment
OFFLINE_GRACE_PERIOD=1h
```

**Format:** Go duration string (`1h`, `30m`, `24h`, etc.)  
**Default:** `0` (disabled — original behavior preserved)

---

## Logging

On startup (after panel connects), the node logs:

```
offline grace period enabled: keepAlive=1m0s grace=5m0s effectiveTimeout=6m0s
```

On invalid value:

```
warning: invalid OFFLINE_GRACE_PERIOD value "abc": time: invalid duration "abc"
```

---

## Testing

```bash
# Build locally
go build ./...

# Build Docker image
docker build -t pasarguard/node:custom .

# Run with grace period
docker run -e OFFLINE_GRACE_PERIOD=5m pasarguard/node:custom

# Test: block panel connection with iptables
sudo iptables -A INPUT -s <PANEL_IP> -p tcp --dport 62050 -j DROP

# Observe logs - disconnect should occur after keepAlive + grace period
docker logs -f pasarguard-node

# Cleanup
sudo iptables -D INPUT -s <PANEL_IP> -p tcp --dport 62050 -j DROP
```

---

## Backward Compatibility

✅ **Fully backward compatible** — if `OFFLINE_GRACE_PERIOD` is not set, behavior is identical to the original implementation.

---

## Known Limitations

- **SyncUsers will not be called during offline period.** New users added in the panel will not be synced to the node until the panel reconnects. Revoked users will remain active. This is acceptable for a failover scenario.

---

## Checklist

- [x] Code compiles without errors (`go build ./...`)
- [x] Code passes vet (`go vet ./...`)
- [x] Unit tests pass (`go test ./controller -v`)
- [x] Updated `.env.example`
- [x] Backward compatibility confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `OFFLINE_GRACE_PERIOD` environment variable that extends the timeout window for disconnect detection, allowing for more graceful handling of temporary connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->